### PR TITLE
Fix: Remove malformed quotes from PATH environment to prevent build failures on Windows relating to powershell parsing

### DIFF
--- a/src/main/java/org/btik/espidf/environment/IdfEnvironmentServiceImpl.java
+++ b/src/main/java/org/btik/espidf/environment/IdfEnvironmentServiceImpl.java
@@ -108,8 +108,9 @@ public class IdfEnvironmentServiceImpl implements IdfEnvironmentService {
             return;
         }
         try {
-            environments = ApplicationManager.getApplication()
+            Map<String, String> rawEnv = ApplicationManager.getApplication()
                     .executeOnPooledThread(() -> readEnvironment(toolchain, environment)).get();
+            environments = sanitizeEnv(rawEnv);
             environmentFile = environment;
 
         } catch (InterruptedException | ExecutionException e) {
@@ -217,6 +218,19 @@ public class IdfEnvironmentServiceImpl implements IdfEnvironmentService {
                         }
                 ));
         return idfToolChain;
+    }
+    private Map<String, String> sanitizeEnv(Map<String, String> env) {
+        Map<String, String> cleanEnv = new HashMap<>();
+        for (Map.Entry<String, String> entry : env.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (key.equalsIgnoreCase("PATH")) {
+                // making sure to remove extra quotes and semicolon-prefixes
+                value = value.replace("\"", "").replaceAll("^;+|;+$", "");
+            }
+            cleanEnv.put(key, value);
+        }
+        return cleanEnv;
     }
 
 }


### PR DESCRIPTION

This PR addresses an issue where the plugin-generated environment (`PATH` in particular) includes incorrectly quoted paths.
### How was it fixed?

- After reading the toolchain environment via `readEnvironment(...)`, I sanitize the `PATH` key to:
  - Remove stray quotation marks (`"`)
  - Remove accidental leading or trailing semicolons (`;`)
- This logic is encapsulated in a helper function `sanitizeEnv(...)` inside `IdfEnvironmentServiceImpl.java`.

---

### How was it tested?

- Built the plugin with the fix
- Installed locally in CLion 2023.1 and tested against an ESP-IDF project
- Confirmed that:
  - `PATH` is now clean and valid
  - Ninja builds succeed
  - No regressions observed

---

### Reproducing the Bug (Pre-fix)

1. Use plugin version `0.4.2`
2. Use an ESP-IDF project on Windows
3. Click **Build** in the plugin tasks
4. Observe the build process failing with:
   ```
   At line:1 char:1093
   ... 2\OpenSSH\;"C:\Espressif\tools\xtensa-esp-elf-gdb\14.2_20240403\xtens ...
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   Unexpected token 'C:\Espressif\tools\xtensa-esp-elf-gdb\14.2_20240403\xtensa-esp-elf-gdb\bin' in expression or statement.
     CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
     FullyQualifiedErrorId : UnexpectedToken
   ```
5. Check exporting environment — you’ll see malformed `PATH` which has quotes in it like `;"C:\...`
